### PR TITLE
Organize chapters by folder

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,21 +12,14 @@
 <div class="container">
     <h2>📖 Lecteur de Documents Word ipad</h2>
 
+    <select id="dossier-select" class="btn-select">
+        <option value="">-- Choisis un dossier --</option>
+        <option value="chapitres_traduits1">chapitres_traduits1</option>
+        <option value="chapitres_traduits2">chapitres_traduits2</option>
+    </select>
+
     <select id="chapitre-select" class="btn-select">
         <option value="">-- Choisis un chapitre --</option>
-        <option value="docs/chapitres_traduits1/Chapitres_1-5.docx">Chapitres 1-5</option>
-        <option value="docs/chapitres_traduits1/Chapitres_6-10.docx">Chapitres 6-10</option>
-        <option value="docs/chapitres_traduits1/Chapitres_11-15.docx">Chapitres 11-15</option>
-        <option value="docs/chapitres_traduits1/Chapitres_16-20.docx">Chapitres 16-20</option>
-        <option value="docs/chapitres_traduits1/Chapitres_21-25.docx">Chapitres 21-25</option>
-        <option value="docs/chapitres_traduits1/Chapitres_26-30.docx">Chapitres 26-30</option>
-        <option value="docs/chapitres_traduits1/Chapitres_31-35.docx">Chapitres 31-35</option>
-        <option value="docs/chapitres_traduits1/Chapitres_36-40.docx">Chapitres 36-40</option>
-        <option value="docs/chapitres_traduits1/Chapitres_41-45.docx">Chapitres 41-45</option>
-        <option value="docs/chapitres_traduits1/Chapitres_46-50.docx">Chapitres 46-50</option>
-        <option value="docs/chapitres_traduits1/Chapitres_51-55.docx">Chapitres 51-55</option>
-        <option value="docs/chapitres_traduits1/Chapitres_56-60.docx">Chapitres 56-60</option>
-        <option value="docs/chapitres_traduits1/Chapitres_61-65.docx">Chapitres 61-65</option>
     </select>
 
     <button onclick="chargerChapitre()">Afficher le chapitre</button>

--- a/scripts.js
+++ b/scripts.js
@@ -1,50 +1,76 @@
-const fileInput = document.getElementById('file-input');
 const docDisplay = document.getElementById('doc-display');
+const dossierSelect = document.getElementById('dossier-select');
 const chapitreSelect = document.getElementById('chapitre-select');
 
-// Événement bouton pour ouvrir la sélection fichier
-document.querySelector('.btn-select').addEventListener('click', () => {
-    fileInput.click();
-});
+const dossiers = {
+    'chapitres_traduits1': [
+        'Chapitres_1-5.docx',
+        'Chapitres_6-10.docx',
+        'Chapitres_11-15.docx',
+        'Chapitres_16-20.docx',
+        'Chapitres_21-25.docx',
+        'Chapitres_26-30.docx',
+        'Chapitres_31-35.docx',
+        'Chapitres_36-40.docx',
+        'Chapitres_41-45.docx',
+        'Chapitres_46-50.docx',
+        'Chapitres_51-55.docx',
+        'Chapitres_56-60.docx',
+        'Chapitres_61-65.docx'
+    ],
+    'chapitres_traduits2': [
+        'Chapitres_1-5.docx',
+        'Chapitres_6-10.docx',
+        'Chapitres_11-15.docx',
+        'Chapitres_16-20.docx',
+        'Chapitres_21-25.docx',
+        'Chapitres_26-30.docx',
+        'Chapitres_31-35.docx',
+        'Chapitres_36-40.docx',
+        'Chapitres_41-45.docx',
+        'Chapitres_46-50.docx',
+        'Chapitres_51-55.docx',
+        'Chapitres_56-60.docx',
+        'Chapitres_61-65.docx',
+        'Chapitres_66-70.docx',
+        'Chapitres_71-75.docx',
+        'Chapitres_76-80.docx',
+        'Chapitres_81-85.docx',
+        'Chapitres_86-90.docx',
+        'Chapitres_91-95.docx',
+        'Chapitres_96-100.docx'
+    ]
+};
 
-// Charger document depuis l'ordinateur local (si utilisé)
-fileInput.addEventListener('change', function(event) {
-    const file = event.target.files[0];
-
-    if (file) {
-        const reader = new FileReader();
-
-        reader.onload = function(loadEvent) {
-            mammoth.convertToHtml({arrayBuffer: loadEvent.target.result})
-                .then(result => {
-                    docDisplay.innerHTML = result.value;
-                })
-                .catch(err => {
-                    docDisplay.innerHTML = `<span style="color:red;">Erreur: ${err.message}</span>`;
-                });
-        };
-
-        reader.readAsArrayBuffer(file);
-    } else {
-        docDisplay.textContent = "Aucun document sélectionné.";
+function remplirChapitres() {
+    chapitreSelect.innerHTML = '<option value="">-- Choisis un chapitre --</option>';
+    const dossier = dossierSelect.value;
+    if (dossier && dossiers[dossier]) {
+        dossiers[dossier].forEach(fichier => {
+            const option = document.createElement('option');
+            option.value = `docs/${dossier}/${fichier}`;
+            option.textContent = fichier.replace('Chapitres_', 'Chapitres ').replace('.docx', '');
+            chapitreSelect.appendChild(option);
+        });
     }
-});
+}
 
-// NOUVELLE FONCTION : Charger depuis les chapitres du serveur directement
+dossierSelect.addEventListener('change', remplirChapitres);
+
 function chargerChapitre() {
     const fichier = chapitreSelect.value;
 
-    if (fichier === "") {
+    if (fichier === '') {
         alert("Sélectionne d'abord un chapitre !");
         return;
     }
 
     fetch(fichier)
         .then(response => {
-            if (!response.ok) throw new Error("Erreur lors du chargement du document");
+            if (!response.ok) throw new Error('Erreur lors du chargement du document');
             return response.arrayBuffer();
         })
-        .then(arrayBuffer => mammoth.convertToHtml({arrayBuffer: arrayBuffer}))
+        .then(arrayBuffer => mammoth.convertToHtml({ arrayBuffer }))
         .then(result => {
             docDisplay.innerHTML = result.value;
         })


### PR DESCRIPTION
## Summary
- allow choosing between two chapter folders
- populate chapters list based on selected folder

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688614e86fdc83228683029631e2677c